### PR TITLE
chore(renovate): automerge github-actions majors without dashboard approval

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,6 +32,17 @@
       ]
     },
     {
+      "groupName": "github actions (major)",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": true,
+      "dependencyDashboardApproval": false
+    },
+    {
       "matchManagers": [
         "gomod"
       ],


### PR DESCRIPTION
Major GitHub Actions updates were stuck behind the Dependency Dashboard approval gate (12 pending in #10), leaving workflows on deprecated runtimes (Node 20 warnings on checkout@v4, setup-go@v5, docker/*@v3-v5, codeql@v3, ...).

This adds a package rule so `github-actions` majors skip `dependencyDashboardApproval` and automerge like minors/patches, grouped as **github actions (major)** so a wave of majors arrives as a single PR (one 55-min docker run instead of twelve).

Go module majors keep the approval gate — those genuinely need review.

Once merged, Renovate should create the grouped actions PR on its next run without any dashboard interaction.

Config validated with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)