### PR TITLE
fix: resolve gosec code-scanning findings

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -200,7 +200,7 @@ func UpdateREADME() error {
 	}
 	data = append(data, "```\n"...)
 
-	if err := os.WriteFile("README.md", data, 0o600); err != nil {
+	if err := os.WriteFile("README.md", data, 0o600); err != nil { // #nosec G703 -- constant path
 		return err
 	}
 	stepOKPrintln("Updating README.md OK")

--- a/pkg/mutators/single/0stdconfigbuilders.go
+++ b/pkg/mutators/single/0stdconfigbuilders.go
@@ -1,12 +1,27 @@
 package mutators
 
 import (
+	"math"
 	"strconv"
 	"strings"
 
 	"github.com/batmac/ccat/pkg/mutators"
 	"github.com/batmac/ccat/pkg/stringutils"
 )
+
+// cfgInt converts a config value produced by stdConfigUint64WithDefault to
+// int, decoding the two's-complement encoding used for negative arguments
+// (e.g. gzip's default level ^uint64(0) means -1) and clamping to the int32
+// range so the result is the same on 32-bit and 64-bit platforms.
+func cfgInt(c any) int {
+	i := int64(c.(uint64)) // #nosec G115 -- deliberate two's-complement decode of "-n" args
+	if i > math.MaxInt32 {
+		i = math.MaxInt32
+	} else if i < math.MinInt32 {
+		i = math.MinInt32
+	}
+	return int(i)
+}
 
 func stdConfigHumanSizeAsInt64(args []string) (any, error) {
 	if len(args) != 1 {

--- a/pkg/mutators/single/bzip2.go
+++ b/pkg/mutators/single/bzip2.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 func cbzip2(w io.WriteCloser, r io.ReadCloser, config any) (int64, error) {
-	lvl := int(config.(uint64)) //nolint:gosec
+	lvl := cfgInt(config)
 	log.Debugf("compression level: %d", lvl)
 	zw, err := bzip2.NewWriter(w, &bzip2.WriterConfig{Level: lvl})
 	if err != nil {
@@ -41,8 +41,8 @@ func cbzip2(w io.WriteCloser, r io.ReadCloser, config any) (int64, error) {
 } */
 
 func punzip2(w io.WriteCloser, r io.ReadCloser, config any) (int64, error) {
-	concurrency := int(config.(uint64)) //nolint:gosec
-	if concurrency == 0 {
+	concurrency := cfgInt(config)
+	if concurrency <= 0 {
 		concurrency = runtime.NumCPU()
 	}
 	return io.Copy(w, pbzip2.NewReader(context.Background(), r, pbzip2.DecompressionOptions(pbzip2.BZConcurrency(concurrency))))

--- a/pkg/mutators/single/huggingface.go
+++ b/pkg/mutators/single/huggingface.go
@@ -147,6 +147,7 @@ func huggingface(w io.WriteCloser, r io.ReadCloser, conf any) (int64, error) {
 
 	log.Debugf("request: %s\n", request)
 
+	// #nosec G704 -- the URL is chosen by the local user (endpoint env var or model argument), like curl
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(request))
 	if err != nil {
 		return 0, err
@@ -161,7 +162,7 @@ func huggingface(w io.WriteCloser, r io.ReadCloser, conf any) (int64, error) {
 		return 0, nil
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- see above, user-chosen URL
 	if err != nil {
 		return 0, err
 	}
@@ -191,9 +192,9 @@ func getHuggingFaceToken() (string, string, error) {
 	// then the content of the file $HF_HOME/token
 	// then the content of the file ~/.huggingface/token
 	// and finally the content of the file ~/.cache/huggingface/token
-	token, source := os.Getenv("HUGGING_FACE_HUB_TOKEN"), "HUGGING_FACE_HUB_TOKEN"
+	token, source := os.Getenv("HUGGING_FACE_HUB_TOKEN"), "HUGGING_FACE_HUB_TOKEN" // #nosec G101 -- env var name, not a credential
 	if token == "" {
-		token, source = os.Getenv("HF_API_KEY"), "HF_API_KEY"
+		token, source = os.Getenv("HF_API_KEY"), "HF_API_KEY" // #nosec G101 -- env var name, not a credential
 	}
 	for _, path := range []string{"$HF_HOME/token", "~/.huggingface/token", "~/.cache/huggingface/token"} {
 		if token != "" {

--- a/pkg/mutators/single/jsonIndent.go
+++ b/pkg/mutators/single/jsonIndent.go
@@ -14,7 +14,10 @@ func init() {
 }
 
 func jsonIndent(w io.WriteCloser, r io.ReadCloser, config any) (int64, error) {
-	indent := int(config.(uint64))
+	indent := cfgInt(config)
+	if indent < 0 {
+		indent = 0
+	}
 	j, err := io.ReadAll(r) // NOT streamable
 	if err != nil {
 		return 0, err

--- a/pkg/mutators/single/lz4.go
+++ b/pkg/mutators/single/lz4.go
@@ -29,10 +29,13 @@ func unlz4(out io.WriteCloser, in io.ReadCloser, _ any) (int64, error) {
 }
 
 func clz4(out io.WriteCloser, in io.ReadCloser, config any) (int64, error) {
-	c := config.(uint64)
+	lvl := cfgInt(config)
+	if lvl < 0 || lvl > 9 {
+		log.Fatal("lz4 compression level must be 0-9")
+	}
 	compressionLevel := lz4.Fast
-	if c != 0 {
-		compressionLevel = lz4.CompressionLevel(1 << (8 + lz4.CompressionLevel(c)))
+	if lvl != 0 {
+		compressionLevel = lz4.CompressionLevel(1 << (8 + lvl))
 	}
 	log.Debugf("compression level: %s", compressionLevel)
 	e := lz4.NewWriter(out)

--- a/pkg/mutators/single/minlz.go
+++ b/pkg/mutators/single/minlz.go
@@ -17,7 +17,7 @@ func init() {
 }
 
 func cminlz(out io.WriteCloser, in io.ReadCloser, c any) (int64, error) {
-	compressionLevel := int(c.(uint64))
+	compressionLevel := cfgInt(c)
 	d := minlz.NewWriter(out, minlz.WriterLevel(compressionLevel))
 	n, err := io.Copy(d, in)
 	d.Close()

--- a/pkg/mutators/single/pv.go
+++ b/pkg/mutators/single/pv.go
@@ -18,7 +18,10 @@ func init() {
 }
 
 func pv(w io.WriteCloser, r io.ReadCloser, config any) (int64, error) {
-	option := config.(uint64)
+	interval := cfgInt(config)
+	if interval <= 0 {
+		interval = 1000 // keep the default, and avoid a zero division below
+	}
 
 	done := make(chan struct{})
 	defer close(done)
@@ -33,13 +36,13 @@ func pv(w io.WriteCloser, r io.ReadCloser, config any) (int64, error) {
 			select {
 			case <-done:
 				return
-			case <-time.After(time.Duration(option) * time.Millisecond):
+			case <-time.After(time.Duration(interval) * time.Millisecond):
 				prefix := ""
 				if log.DebugIsDiscard == 1 {
 					prefix = "\x1b[A\x1b[2K" // go on the previous line and erase the line
 				}
 				newTotal := totalWritten.Load()
-				computedDiff := stringutils.HumanSize((newTotal - oldTotal) * 1000 / int64(option))
+				computedDiff := stringutils.HumanSize((newTotal - oldTotal) * 1000 / int64(interval))
 				oldTotal = newTotal
 
 				fmt.Fprintf(os.Stderr, "%s%s [%s/s]     \n", prefix, stringutils.HumanSize(newTotal), computedDiff)

--- a/pkg/mutators/single/stdCompress.go
+++ b/pkg/mutators/single/stdCompress.go
@@ -60,7 +60,7 @@ func unzlib(w io.WriteCloser, r io.ReadCloser, _ any) (int64, error) {
 }
 
 func cgzip(w io.WriteCloser, r io.ReadCloser, config any) (int64, error) {
-	lvl := int(config.(uint64))
+	lvl := cfgInt(config)
 	// log.Printf("compression level: %d", lvl)
 	zw, err := gzip.NewWriterLevel(w, lvl)
 	if err != nil {
@@ -72,7 +72,7 @@ func cgzip(w io.WriteCloser, r io.ReadCloser, config any) (int64, error) {
 }
 
 func czlib(w io.WriteCloser, r io.ReadCloser, config any) (int64, error) {
-	lvl := int(config.(uint64))
+	lvl := cfgInt(config)
 	log.Debugf("compression level: %d", lvl)
 	zw, err := zlib.NewWriterLevel(w, lvl)
 	if err != nil {

--- a/pkg/mutators/single/wrap.go
+++ b/pkg/mutators/single/wrap.go
@@ -28,7 +28,7 @@ func init() {
 }
 
 func wordWrap(w io.WriteCloser, r io.ReadCloser, config any) (int64, error) {
-	WrapMaxChars := int(config.(uint64))
+	WrapMaxChars := cfgInt(config)
 	ww := wordwrap.NewWriter(WrapMaxChars)
 	if _, err := io.Copy(ww, r); err != nil { // streamable?
 		return 0, err
@@ -38,7 +38,7 @@ func wordWrap(w io.WriteCloser, r io.ReadCloser, config any) (int64, error) {
 }
 
 func unconditionalyWrap(w io.WriteCloser, r io.ReadCloser, config any) (int64, error) {
-	WrapMaxChars := int(config.(uint64))
+	WrapMaxChars := cfgInt(config)
 	ww := uwrap.NewWriter(WrapMaxChars)
 	if _, err := io.Copy(ww, r); err != nil { // streamable?
 		return 0, err

--- a/pkg/mutators/single/zstd.go
+++ b/pkg/mutators/single/zstd.go
@@ -38,7 +38,7 @@ func unzstd(out io.WriteCloser, in io.ReadCloser, _ any) (int64, error) {
 }
 
 func czstd(out io.WriteCloser, in io.ReadCloser, conf any) (int64, error) {
-	encoderLvl := zstd.EncoderLevelFromZstd(int(conf.(uint64)))
+	encoderLvl := zstd.EncoderLevelFromZstd(cfgInt(conf))
 	log.Debugf("zstd compression level: %d (-> %v)\n", conf.(uint64), encoderLvl)
 	e, err := zstd.NewWriter(out, zstd.WithEncoderLevel(encoderLvl))
 	if err != nil {

--- a/pkg/openers/mc.go
+++ b/pkg/openers/mc.go
@@ -26,7 +26,8 @@ var (
 	mcOpenerDescription = "get a Minio-compatible object via mc:// (use ~/.mc/config.json or env for credentials)"
 
 	mcConfigPath = "/.mc/config.json"
-	EnvVar       = Config{
+	// #nosec G101 -- environment variable names, not credentials
+	EnvVar = Config{
 		Endpoint:        "AWS_ENDPOINT",
 		AccessKeyID:     "AWS_ACCESS_KEY_ID",
 		SecretAccessKey: "AWS_SECRET_ACCESS_KEY",

--- a/pkg/pcg/pcg32.go
+++ b/pkg/pcg/pcg32.go
@@ -8,7 +8,7 @@ type PCG32 struct {
 func (pcg *PCG32) Next() uint32 {
 	oldstate := pcg.state
 	pcg.state = oldstate*6364136223846793005 + (pcg.inc | 1)
-	xorshifted := uint32(((oldstate >> 18) ^ oldstate) >> 27)
+	xorshifted := uint32(((oldstate >> 18) ^ oldstate) >> 27) // #nosec G115 -- deliberate truncation, per the PCG algorithm
 	rot := uint32(oldstate >> 59)
 	return (xorshifted >> rot) | (xorshifted << ((-rot) & 31))
 }


### PR DESCRIPTION
Resolves the 17 open gosec code-scanning alerts (G115 ×12, G704 ×2, G101, G703), analyzed individually:

**Real fixes**
- **G115 (unchecked `uint64` → `int` casts on user-supplied mutator args)**: added a single `cfgInt` helper in `0stdconfigbuilders.go` that decodes the two's-complement encoding used for negative args (this is load-bearing: `gzip`'s default level is `^uint64(0)` = `-1` = `gzip.DefaultCompression`) and clamps to the int32 range so results are identical on 32/64-bit. Applied at all flagged sites (minlz, bzip2, jsonIndent, stdCompress, wrap, zstd, lz4, pv).
- **pv**: `-m pv:0` previously caused a division by zero in the rate-printing goroutine; the interval is now guarded.
- **jsonIndent**: a negative indent previously panicked in `strings.Repeat`; now clamped to 0.
- **lz4**: compression level is validated 0–9 explicitly instead of failing deep in `Apply`.

**Justified suppressions (false positives)**
- **pcg32 (G115)**: the `uint32` truncation is the PCG algorithm's definition.
- **mc.go / huggingface.go (G101)**: flagged strings are environment-variable *names*, not credentials. (Also replaced two `//nolint:gosec` comments, which standalone gosec ignores, with proper `#nosec` directives.)
- **huggingface.go (G704 SSRF)**: the URL is chosen by the local user (endpoint env var or model CLI arg) — same trust model as curl.
- **magefile.go (G703)**: `os.WriteFile("README.md", ...)` is a constant path.

Verified: `go build ./cmd/ccat`, `go vet ./pkg/...`, `go test ./pkg/...` all pass; `gosec -severity high ./...` (the CI configuration) reports zero issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)