### PR TITLE
ci: validate linux/arm64 build on PRs too

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -17,24 +17,46 @@ env:
   GHCR_IMAGE: ghcr.io/batmac/ccat
 
 jobs:
-  # PR / merge-queue check: fast native amd64 build, nothing is pushed
-  docker:
+  # PR / merge-queue check: fast native builds of both platforms, nothing is pushed
+  pr-build:
     if: github.event_name != 'push'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
+
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Build (amd64 only, no push)
+      - name: Build (no push)
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: false
-          cache-from: type=gha,scope=linux-amd64
-          cache-to: type=gha,mode=max,scope=linux-amd64
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+
+  # gate job keeping the required status-check context named "docker"
+  docker:
+    if: ${{ !cancelled() && github.event_name != 'push' }}
+    needs: pr-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: All platform builds succeeded
+        run: test "${{ needs.pr-build.result }}" = "success"
 
   # main/tags: build each platform natively and push by digest
   build:


### PR DESCRIPTION
Closes the gap from #1153: the PR check built only amd64, so an arm64-specific breakage would surface only after merge. The PR check is now a two-platform matrix (amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`), both native, parallel, and push-free — so it stays ~3 min wall-clock.

The required branch-protection context is named `docker`, so a small gate job with that name `needs: pr-build` and fails unless every matrix leg succeeded (`!cancelled()` guard so it reports on failures too).

Published images are unchanged: main/tags still build and push amd64+arm64 manifests as before.

This PR's own checks exercise the new matrix. Validated with actionlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)