### PR TITLE
chore: dependency-automation hygiene (weekly grouped updates, close coverage holes)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get -y upgrad
 
 # [Optional] Uncomment the next lines to use go get to install anything else you need
 USER vscode
+# dev tool: latest is intentional here
+# hadolint ignore=DL3062
 RUN go install mvdan.cc/gofumpt@latest
 
 # [Optional] Uncomment this line to install global node packages.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,8 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/go/.devcontainer/base.Dockerfile
+# See https://github.com/devcontainers/images/tree/main/src/go
 
-# [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.19, 1.18, 1-bullseye, 1.19-bullseye, 1.18-bullseye, 1-buster, 1.19-buster, 1.18-buster
-ARG VARIANT="1.19-bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
-
-# [Choice] Node.js version: none, lts/*, 18, 16, 14
-ARG NODE_VERSION="none"
-RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+# [Choice] Go version: 1, 1.27, 1-bookworm, 1.27-bookworm, ...
+ARG VARIANT="1-bookworm"
+FROM mcr.microsoft.com/devcontainers/go:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.
 # hadolint ignore=DL3008,DL3009

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,12 +5,9 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			// Update the VARIANT arg to pick a version of Go: 1, 1.19, 1.18
-			// Append -bullseye or -buster to pin to an OS version.
-			// Use -bullseye variants on local arm64/Apple Silicon.
-			"VARIANT": "1-bullseye",
-			// Options
-			"NODE_VERSION": "lts/*"
+			// Update the VARIANT arg to pick a version of Go: 1, 1.27
+			// Append -bookworm to pin to an OS version.
+			"VARIANT": "1-bookworm"
 		}
 	},
 	"runArgs": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,11 @@
   "dependencyDashboardAutoclose": true,
   "extends": [
     "config:recommended",
-    ":rebaseStalePrs"
+    ":rebaseStalePrs",
+    "schedule:weekly",
+    "group:allNonMajor",
+    "helpers:pinGitHubActionDigests",
+    "docker:pinDigests"
   ],
   "labels": [
     "renovate"
@@ -49,6 +53,16 @@
       "digest": {
         "dependencyDashboardApproval": true
       }
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepTypes": [
+        "indirect"
+      ],
+      "enabled": true,
+      "groupName": "go indirect dependencies"
     },
     {
       "groupName": "aws-go-sdk-v2 monorepo",

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v7
       - name: Security Scan
-        uses: securego/gosec@master
+        uses: securego/gosec@v2.28.0
         with:
           # we let the report trigger content trigger a failure using the GitHub Security features.
           args: " -severity high -no-fail -fmt sarif -out results.sarif ./..."

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: "fs"
           ignore-unfixed: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 ci:
   # renovate-config-validator's hook env exceeds pre-commit.ci's 250MiB tier
   skip: ["golangci-lint", "renovate-config-validator"]
+  # hook updates are owned by Renovate (weekly, grouped); keep pre-commit.ci quiet
+  autoupdate_schedule: quarterly
 exclude: testdata/|generated|devcontainer\.json
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN go mod download
 COPY . .
 ENV CGO_ENABLED=1
 # zero-install mage: version pinned by go.mod instead of @latest
+# hadolint ignore=DL3062
 RUN go version && go run magefiles/mage.go buildFull
 
 FROM alpine:3.22

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,15 @@ WORKDIR /usr/src/app
 COPY go.mod go.sum ./
 # hadolint ignore=DL3018
 RUN apk upgrade --no-cache \
-    && apk add --no-cache build-base pkgconf curl-dev git bash \
-    && go install github.com/magefile/mage@latest
+    && apk add --no-cache build-base pkgconf curl-dev git bash
 # populate the module cache in its own layer, invalidated only by go.mod/go.sum
 RUN go mod download
 COPY . .
-ENV CGO_ENABLED 1
-RUN go version && mage buildFull
+ENV CGO_ENABLED=1
+# zero-install mage: version pinned by go.mod instead of @latest
+RUN go version && go run magefiles/mage.go buildFull
 
-FROM alpine:20250108
+FROM alpine:3.22
 # hadolint ignore=DL3018
 RUN apk upgrade --no-cache && apk add --no-cache libcurl tini
 COPY "entrypoint.sh" "/entrypoint.sh"

--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -3,14 +3,16 @@ WORKDIR /usr/src/app
 # install git for go buildinfo (-B)
 # hadolint ignore=DL3018
 RUN apk upgrade --no-cache \
-    && apk add --no-cache git \
-    && go install github.com/magefile/mage@latest
+    && apk add --no-cache git
+COPY go.mod go.sum ./
+RUN go mod download
 COPY . .
-ENV CGO_ENABLED 0
-RUN go version && mage
+ENV CGO_ENABLED=0
+# zero-install mage: version pinned by go.mod instead of @latest
+RUN go version && go run magefiles/mage.go
 
 # hadolint ignore=DL3006
-FROM gcr.io/distroless/static-debian11
+FROM gcr.io/distroless/static-debian12
 COPY --from=build /usr/src/app/ccat /usr/bin/ccat
 USER 1000
 ENTRYPOINT ["/usr/bin/ccat"]

--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -9,6 +9,7 @@ RUN go mod download
 COPY . .
 ENV CGO_ENABLED=0
 # zero-install mage: version pinned by go.mod instead of @latest
+# hadolint ignore=DL3062
 RUN go version && go run magefiles/mage.go
 
 # hadolint ignore=DL3006


### PR DESCRIPTION
Closes the coverage holes from the update-automation audit, and switches to a weekly, grouped cadence:

**Renovate config**
- `schedule:weekly` — updates land Monday mornings (Europe/Paris) instead of dribbling in all week; Renovate's vulnerability-alert PRs and Dependabot security PRs still bypass the schedule
- `group:allNonMajor` — all non-major bumps arrive as **one weekly PR**
- indirect Go modules are now managed (grouped as their own PR) — previously invisible until a Trivy alert (the x/image case)
- `helpers:pinGitHubActionDigests` + `docker:pinDigests` — actions and base images get digest-pinned (Renovate will open a one-time pin PR, then digest updates automerge inside the weekly batch)

**Unpinned/stale things fixed**
- `securego/gosec@master` → `@v2.28.0`, `aquasecurity/trivy-action@master` → `@v0.36.0` (Renovate now manages them)
- `alpine:20250108` (19-month-old date tag Renovate couldn't parse) → `alpine:3.22`
- distroless base → `static-debian12`
- `mage@latest` in both Dockerfiles → zero-install `go run magefiles/mage.go`, version pinned by go.mod; also `ENV key=value` format (BuildKit warning)
- devcontainer → `mcr.microsoft.com/devcontainers/go:1-bookworm` (old namespace is deprecated and was pinned to a Go-1.19-era tag); drops the node install that a base-image change would have broken
- pre-commit.ci autoupdate → quarterly; Renovate owns hook updates (ends the two-bots-updating-the-same-file situation)

Validated: `renovate-config-validator` passes, actionlint clean, and **both Dockerfiles build locally** — the main image runs (`ccat --version`, full tags, built by zero-install mage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)