### PR TITLE
ci: least-privilege GITHUB_TOKEN permissions for all workflows

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -83,6 +83,6 @@
     "gomodTidy"
   ],
   "prHourlyLimit": 3,
-  "minimumReleaseAge": "1 day",
+  "minimumReleaseAge": "7 days",
   "timezone": "Europe/Paris"
 }

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -12,6 +12,9 @@ concurrency:
   group: buildx-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 env:
   DOCKERHUB_IMAGE: batmac/ccat
   GHCR_IMAGE: ghcr.io/batmac/ccat
@@ -61,6 +64,9 @@ jobs:
   # main/tags: build each platform natively and push by digest
   build:
     if: github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -131,6 +137,9 @@ jobs:
   merge:
     if: github.event_name == 'push'
     needs: build
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Download digests

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   go:
     strategy:

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: "0 0 * * 0"
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   sec-gosec:
     runs-on: ubuntu-latest

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -10,6 +10,9 @@ on:
   merge_group:
 
 
+permissions:
+  contents: read
+
 jobs:
   makefile:
     runs-on: ubuntu-latest

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -6,6 +6,8 @@ on:
     types:
       - opened
 
+permissions: {}
+
 jobs:
   add-to-project:
     name: Add to project

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: "0 0 * * 0"
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   trivy:
     runs-on: ubuntu-latest

--- a/.github/workflows/vendored.yml
+++ b/.github/workflows/vendored.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  contents: write
+
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds explicit `permissions:` blocks to the 8 workflows that had none (codeql and dependency-review already had them), following least privilege:

| Workflow | Token scopes |
|---|---|
| go, makefile, dockerhub-description | `contents: read` |
| gosec, trivy | `contents: read` + `security-events: write` (SARIF upload) |
| docker-images | `contents: read` workflow-wide; `packages: write` only in the two publish jobs (ghcr) — PR jobs never get a write token |
| vendored | `contents: write` (force-pushes the vendored branch) |
| project | `permissions: {}` — it authenticates with a PAT, the workflow token is unused |

Once merged, the repo default workflow token will be flipped from **write** to **read** and workflow PR-approval disabled (settings change, not in this diff) — every workflow then carries exactly the scopes it declares, and a compromised third-party action gets a read-only token unless its job explicitly needs more.

Also: `minimumReleaseAge` 1 day → **7 days** — with everything automerging weekly, the extra cooldown against yanked/compromised releases costs only latency.

Validated with actionlint and renovate-config-validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)