### PR TITLE
chore(renovate): hold cloud.google.com/go/ai (generative-ai-go constraint)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -65,6 +65,16 @@
       "groupName": "go indirect dependencies"
     },
     {
+      "description": "constrained by the deprecated github.com/google/generative-ai-go, whose build breaks against newer go/ai; remove after migrating to google.golang.org/genai",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "cloud.google.com/go/ai"
+      ],
+      "enabled": false
+    },
+    {
       "groupName": "aws-go-sdk-v2 monorepo",
       "groupSlug": "aws-go-sdk-v2",
       "matchDatasources": [


### PR DESCRIPTION
The first "go indirect dependencies" batch (#1158) fails to build: bumping `cloud.google.com/go/ai` v0.8.0 → v0.20.0 breaks compilation of `github.com/google/generative-ai-go` v0.20.1 (deprecated and frozen upstream — its genai package targets the old `generativelanguagepb` API). Verified locally: with go/ai held at v0.8.0, the remaining 28 indirect bumps build and pass tests.

This excludes `cloud.google.com/go/ai` from Renovate updates with an explanatory description. After merge, #1158 needs a rebase (Renovate will drop the go/ai bump from the group).

The real fix, someday: migrate the gemini mutator from the deprecated `generative-ai-go` to `google.golang.org/genai`, then delete this rule.

The required-check gate worked as intended: the broken batch could not automerge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)