### PR TITLE
chore(build): self-contained janitor target, drop dead tooling

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -88,6 +88,19 @@
       ]
     }
   ],
+  "customManagers": [
+    {
+      "description": "go run tool pins in the Makefile",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^Makefile$/"
+      ],
+      "matchStrings": [
+        "(?<depName>[a-z0-9./-]+(?:\\.[a-z]{2,})[^\\s@]*)@(?<currentValue>v[0-9][^\\s]*)"
+      ],
+      "datasourceTemplate": "go"
+    }
+  ],
   "postUpdateOptions": [
     "gomodUpdateImportPaths",
     "gomodTidy"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+GOVULNCHECK := golang.org/x/vuln/cmd/govulncheck@v1.7.0
+GOSEC := github.com/securego/gosec/v2/cmd/gosec@v2.28.0
+GOFUMPT := mvdan.cc/gofumpt@v0.11.0
 
 build:
 	go run magefiles/mage.go
@@ -10,14 +13,14 @@ test:
 thanks:
 	gothanks
 
+# golangci-lint is expected in $PATH: it is still pinned to the v1 config
+# schema, see https://github.com/batmac/ccat/issues/1164
 janitor:
-	golangci-lint --go=1.19 run --disable-all -E misspell --fix ./...
-	golangci-lint --go=1.19 run ./...
-	gofumpt -w -l .
-	gosec -severity high ./...
-	govulncheck ./...
-	go list -json -deps ./... | nancy sleuth
-	pre-commit autoupdate
+	golangci-lint run --disable-all -E misspell --fix ./...
+	golangci-lint run ./...
+	go run $(GOFUMPT) -w -l .
+	go run $(GOSEC) -severity high ./...
+	go run $(GOVULNCHECK) ./...
 
 release:
 	goreleaser release --clean

--- a/cmd/ccat/memoryUsage.go
+++ b/cmd/ccat/memoryUsage.go
@@ -14,6 +14,6 @@ func PrintMemUsage() {
 	// For info on each, see: https://golang.org/pkg/runtime/#MemStats
 	fmt.Fprintf(os.Stderr, "Alloc = %v ", stringutils.HumanSize(m.Alloc))
 	fmt.Fprintf(os.Stderr, "\tTotalAlloc = %v ", stringutils.HumanSize(m.TotalAlloc))
-	fmt.Fprintf(os.Stderr, "\tSys = %v ", stringutils.HumanSize((m.Sys)))
+	fmt.Fprintf(os.Stderr, "\tSys = %v ", stringutils.HumanSize(m.Sys))
 	fmt.Fprintf(os.Stderr, "\tNumGC = %v\n", m.NumGC)
 }

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -193,11 +193,10 @@ func UpdateREADME() error {
 	}
 	data = append(data, "\n```\n"...)
 	out, err := sh.Output("./"+binaryName, "--fullhelp")
-
-	data = append(data, out...)
 	if err != nil {
 		return err
 	}
+	data = append(data, out...)
 	data = append(data, "```\n"...)
 
 	if err := os.WriteFile("README.md", data, 0o600); err != nil { // #nosec G703 -- constant path
@@ -226,6 +225,7 @@ func stepOKPrintln(a ...any) {
 func Macsign() error {
 	if runtime.GOOS != "darwin" {
 		fmt.Println("❗️Skipping macOS signing on non-macOS platform")
+		return nil
 	}
 	stepPrintln("Signing and Notarizing for macOS with `gon` ...")
 	if err := sh.RunV("gon", ".gon.hcl"); err != nil {

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -31,7 +31,7 @@ func TestSetDebug(t *testing.T) {
 	t.Run("bytes.Buffer", func(t *testing.T) {
 		w := &bytes.Buffer{}
 		log.SetDebug(w)
-		if w != (log.Debug.Logger.Writer()) {
+		if w != log.Debug.Logger.Writer() {
 			t.Errorf("SetDebug() = %v, want %v", log.Debug.Logger, w)
 		}
 	})


### PR DESCRIPTION
Mechanical build-system cleanup from the Makefile/magefiles audit. The golangci-lint v2 migration — the one finding with real substance — is tracked separately in #1164 and deliberately **not** in this PR.

## Makefile

- **Dropped `--go=1.19`** (twice): go.mod declares `go 1.26`, so the flag was telling the linter to assume a seven-year-old language version and skip modern checks
- **Dropped `nancy`**: unmaintained since Feb 2023, and redundant with `govulncheck`, which matches the same advisory data *and* does reachability analysis
- **Dropped `pre-commit autoupdate`**: contradicts the update policy set in #1155 (Renovate owns hook updates, pre-commit.ci autoupdate is quarterly)
- **`go run tool@version` for govulncheck / gosec / gofumpt**: `make janitor` previously died on a fresh machine (govulncheck was not installed at all) and silently used whatever global versions happened to be present. Now self-contained and pinned.

`golangci-lint` stays a $PATH command with a comment pointing at #1164 — pinning it here would just freeze the broken v1.

## Renovate

Custom regex manager so the new Makefile pins are updated like everything else, instead of becoming the next stale thing. Validated with `renovate-config-validator` **v43** (the version the hosted app runs — note the npm `latest` dist-tag resolves to v37, which rejects `managerFilePatterns`).

## magefiles — two small real bugs

- `UpdateREADME` appended the `--fullhelp` output *before* checking its error, so a failed run wrote a truncated README
- `Macsign` printed "Skipping on non-macOS platform" and then ran `gon` anyway (missing `return`)

Plus the two redundant-paren fixes `gofumpt -w` produces, since `make janitor` would make them anyway.

**Verified**: `go build ./cmd/ccat`, tests pass, and both `go run` pins execute correctly (govulncheck and gofumpt run clean from a cold cache).

## Not in this PR, deliberately

`gon` (`make macsign`) is archived upstream since 2023. Replacing it with goreleaser's built-in `notarize:` block is release-critical and wants testing on a real tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)