### PR TITLE
chore: migrate golangci-lint to v2 and fix what it found

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,130 +1,98 @@
+version: "2"
 run:
   build-tags:
     - crappy
-
 linters:
   enable:
     - asasalint
     - asciicheck
     - bidichk
     - bodyclose
-    # - containedctx
     - contextcheck
-    # - cyclop
-    # deprecated
-    # - deadcode
     - decorder
-    # - depguard
     - dogsled
     - dupl
     - dupword
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
-    - execinquery
     - exhaustive
-    # deprecated
-    # - exhaustivestruct
-    # - exhaustruct
-    - exportloopref
-    # - forbidigo
-    # - forcetypeassert
-    # - funlen
-    # - gci
     - ginkgolinter
     - gocheckcompilerdirectives
-    # - gochecknoglobals
-    # - gochecknoinits
-    # - gocognit
     - goconst
     - gocritic
-    # - gocyclo
-    # - godot
     - godox
-    # - goerr113
-    - gofmt
-    - gofumpt
     - goheader
-    - goimports
-    # deprecated
-    # - golint
-    # - gomnd
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
     - gosmopolitan
-    - govet
     - grouper
-    # deprecated
-    # - ifshort
     - importas
-    - ineffassign
     - interfacebloat
-    # deprecated
-    # - interfacer
-    # - ireturn
-    # - lll
     - loggercheck
     - maintidx
     - makezero
-    # deprecated
-    # - maligned
     - mirror
     - misspell
-    # - musttag
     - nakedret
-    # - nestif
     - nilerr
     - nilnil
-    # - nlreturn
-    # - noctx
     - nolintlint
     - nonamedreturns
-    # deprecated
-    # - nosnakecase
     - nosprintfhostport
-    # - paralleltest
     - prealloc
     - predeclared
     - promlinter
     - reassign
     - revive
     - rowserrcheck
-    # deprecated
-    # - scopelint
     - sqlclosecheck
     - staticcheck
-    # deprecated
-    # - structcheck
-    - stylecheck
     - tagalign
-    # - tagliatelle
-    - tenv
     - testableexamples
     - testpackage
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
-    # deprecated
-    # - varcheck
-    # - varnamelen
     - wastedassign
     - whitespace
-    # - wrapcheck
-    # - wsl
     - zerologlint
-issues:
-  exclude-use-default: true
-  exclude:
-    - "ST1018: string literal contains Unicode format characters, consider using escape sequences instead"
-linter-settings:
-  gofumpt:
-    extra-rules: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: (.+)\.go$
+        text: 'ST1018: string literal contains Unicode format characters, consider using escape sequences instead'
+      # table-driven tests repeat their fixtures on purpose: extracting them
+      # into constants would make the cases harder to read, not easier
+      - path: _test\.go
+        linters:
+          - goconst
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra:
+        group-params: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/ccat/main.go
+++ b/cmd/ccat/main.go
@@ -120,7 +120,8 @@ func main() {
 				"",
 				strings.ToLower(*argStyle),
 				strings.ToLower(*argFormatter),
-				"go"))
+				"go",
+			))
 		} else {
 			s = b.String()
 		}

--- a/pkg/color/color256.go
+++ b/pkg/color/color256.go
@@ -24,7 +24,7 @@ func (c C256) Sprint(s string) string {
 
 // #nosec
 func (c *C256) Next() Color {
-	rand.Seed(int64(*c))      //nolint:staticcheck
-	n := C256(rand.Intn(230)) //nolint:gosec
+	rand.Seed(int64(*c)) //nolint:staticcheck
+	n := C256(rand.Intn(230))
 	return &n
 }

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -31,7 +31,7 @@ func TestSetDebug(t *testing.T) {
 	t.Run("bytes.Buffer", func(t *testing.T) {
 		w := &bytes.Buffer{}
 		log.SetDebug(w)
-		if w != log.Debug.Logger.Writer() {
+		if w != log.Debug.Writer() {
 			t.Errorf("SetDebug() = %v, want %v", log.Debug.Logger, w)
 		}
 	})

--- a/pkg/mutators/mutators.go
+++ b/pkg/mutators/mutators.go
@@ -40,13 +40,12 @@ type Factory interface {
 }
 
 type mutatorCollection struct {
-	factories    map[string]Factory
-	aliases      map[string]string
-	logger       *log.Logger
-	Name         string
-	mutators     []Mutator
-	argSeparator string
-	mu           sync.Mutex
+	factories map[string]Factory
+	aliases   map[string]string
+	logger    *log.Logger
+	Name      string
+	mutators  []Mutator
+	mu        sync.Mutex
 }
 
 func newCollection(name string, logger *log.Logger) *mutatorCollection {
@@ -73,7 +72,7 @@ func RegisterFactory(name string, factory Factory) error {
 	return nil
 }
 
-func RegisterAlias(name string, alias string) error {
+func RegisterAlias(name, alias string) error {
 	globalCollection.mu.Lock()
 	defer globalCollection.mu.Unlock()
 	// forbid overwriting an existing alias

--- a/pkg/mutators/single/0stdconfigbuilders.go
+++ b/pkg/mutators/single/0stdconfigbuilders.go
@@ -3,9 +3,7 @@ package mutators
 import (
 	"math"
 	"strconv"
-	"strings"
 
-	"github.com/batmac/ccat/pkg/mutators"
 	"github.com/batmac/ccat/pkg/stringutils"
 )
 
@@ -87,16 +85,6 @@ func stdConfigStrings(amin, amax int) configBuilder {
 
 		return args, nil
 	}
-}
-
-func stdConfigStringJoinsArgs(args []string) (any, error) {
-	if len(args) == 0 {
-		return nil, ErrWrongNumberOfArgs(1, -1, 0) // -1 indicates "at least 1"
-	}
-	// Re-join the parts that were split, using the original separator
-	joinedArg := strings.Join(args, mutators.ArgSeparator)
-	// joinedArg = strings.TrimSpace(joinedArg)
-	return joinedArg, nil
 }
 
 func stdConfigInts(amin, amax int) configBuilder {

--- a/pkg/mutators/single/huggingface.go
+++ b/pkg/mutators/single/huggingface.go
@@ -140,7 +140,8 @@ func huggingface(w io.WriteCloser, r io.ReadCloser, conf any) (int64, error) {
 			Inputs:     string(input),
 			Parameters: parameters,
 			Options:    map[string]any{"wait_for_model": true},
-		})
+		},
+	)
 	if err != nil {
 		return 0, err
 	}
@@ -185,7 +186,6 @@ func huggingface(w io.WriteCloser, r io.ReadCloser, conf any) (int64, error) {
 	return int64(n), err
 }
 
-//nolint:gosec
 func getHuggingFaceToken() (string, string, error) {
 	// HUGGING_FACE_HUB_TOKEN,
 	// then HF_API_KEY,

--- a/pkg/mutators/single/openai.go
+++ b/pkg/mutators/single/openai.go
@@ -76,7 +76,10 @@ func chatgpt(w io.WriteCloser, r io.ReadCloser, conf any) (int64, error) {
 		Messages: []gpt.ChatCompletionMessage{
 			{Role: gpt.ChatMessageRoleUser, Content: prePrompt + string(prompt)},
 		},
-		MaxTokens:        maxTokens,
+		// MaxCompletionTokens is the modern field, but OPENAI_BASE_URL lets
+		// users point ccat at OpenAI-compatible servers (llama.cpp, ollama,
+		// LocalAI...) that only understand max_tokens.
+		MaxTokens:        maxTokens, //nolint:staticcheck // SA1019, see above
 		Temperature:      0,
 		TopP:             0,
 		N:                0,

--- a/pkg/mutators/single/pgzip.go
+++ b/pkg/mutators/single/pgzip.go
@@ -46,16 +46,17 @@ func cpgzip(w io.WriteCloser, r io.ReadCloser, config any) (int64, error) {
 	}
 	defer zw.Close()
 
+	// return instead of log.Fatal: exiting here would skip the deferred Close
 	switch len(args) {
 	case 2:
 		log.Debugf("setting block size: %d", args[1])
 		if err := zw.SetConcurrency(args[1], runtime.GOMAXPROCS(0)); err != nil {
-			log.Fatal(err)
+			return 0, err
 		}
 	case 3:
 		log.Debugf("setting block size: %d, blocks: %d", args[1], args[2])
 		if err := zw.SetConcurrency(args[1], args[2]); err != nil {
-			log.Fatal(err)
+			return 0, err
 		}
 	}
 

--- a/pkg/mutators/single/simples_test.go
+++ b/pkg/mutators/single/simples_test.go
@@ -29,7 +29,7 @@ func Test_discard(t *testing.T) {
 
 func Test_wc(t *testing.T) {
 	tests := []struct {
-		name, input string
+		name, input    string
 		expectedCounts map[string]int64 // mode -> expected count
 	}{
 		{"empty", "", map[string]int64{"b": 0, "r": 0, "w": 0, "l": 0}},

--- a/pkg/mutators/single/stdCompress.go
+++ b/pkg/mutators/single/stdCompress.go
@@ -41,10 +41,8 @@ func ungzip(w io.WriteCloser, r io.ReadCloser, _ any) (int64, error) {
 }
 
 func bunzip2(w io.WriteCloser, r io.ReadCloser, _ any) (int64, error) {
+	// bzip2.NewReader never returns nil, there is nothing to check here
 	bzr := bzip2.NewReader(r)
-	if bzr == nil {
-		log.Fatal("bzip2 decompressor failed to init")
-	}
 	//#nosec
 	return io.Copy(w, bzr)
 }

--- a/pkg/mutators/single/wolframalpha.go
+++ b/pkg/mutators/single/wolframalpha.go
@@ -47,7 +47,7 @@ func wolframalphallm(w io.WriteCloser, r io.ReadCloser, _ any) (int64, error) {
 	return wolframalpha(w, r, "llm-api", "input")
 }
 
-func wolframalpha(w io.WriteCloser, r io.ReadCloser, t string, queryField string) (int64, error) {
+func wolframalpha(w io.WriteCloser, r io.ReadCloser, t, queryField string) (int64, error) {
 	baseURL := "https://api.wolframalpha.com/v1/" + t + "?"
 
 	query, err := io.ReadAll(r) // NOT streamable

--- a/pkg/mutators/single/wrap.go
+++ b/pkg/mutators/single/wrap.go
@@ -17,13 +17,16 @@ const (
 
 func init() {
 	singleRegister("wrap", wordWrap, withDescription(
-		fmt.Sprintf("word-wrap the text (to X:%d chars maximum)", WrapMaxChars)),
+		fmt.Sprintf("word-wrap the text (to X:%d chars maximum)", WrapMaxChars),
+	),
 		withConfigBuilder(stdConfigUint64WithDefault(WrapMaxChars)))
 	singleRegister("wrapU", unconditionalyWrap, withDescription(
-		fmt.Sprintf("unconditionally wrap the text (to X:%d chars maximum)", WrapMaxChars)),
+		fmt.Sprintf("unconditionally wrap the text (to X:%d chars maximum)", WrapMaxChars),
+	),
 		withConfigBuilder(stdConfigUint64WithDefault(WrapMaxChars)))
 	singleRegister("indent", singleIndent, withDescription(
-		fmt.Sprintf("indent the text (with X:%d chars)", IndentChars)),
+		fmt.Sprintf("indent the text (with X:%d chars)", IndentChars),
+	),
 		withConfigBuilder(stdConfigUint64WithDefault(IndentChars)))
 }
 

--- a/pkg/openers/mc.go
+++ b/pkg/openers/mc.go
@@ -78,7 +78,8 @@ func (f mcOpener) Open(s string, _ bool) (io.ReadCloser, error) {
 	var alias, bucket, object string
 	var c Config
 
-	if strings.HasPrefix(s, "s3://") {
+	switch {
+	case strings.HasPrefix(s, "s3://"):
 		// s3://bucket/object compat
 		bucket, object = parseS3URIcompat(s)
 		log.Debugf("request to get %s in %s\n", object, bucket)
@@ -88,15 +89,14 @@ func (f mcOpener) Open(s string, _ bool) (io.ReadCloser, error) {
 			SecretAccessKey: os.Getenv(EnvVar.SecretAccessKey),
 		}
 		c = mergeConfig(c, getConfigFromFallback())
-
-	} else if strings.HasPrefix(s, "mc://") {
+	case strings.HasPrefix(s, "mc://"):
 		alias, bucket, object = parseMcURI(s)
 		log.Debugf("request to get '%s' in '%s' from alias '%s'\n", object, bucket, alias)
 
 		log.Debugf(" creating client...\n")
 
 		c = getConfig(alias)
-	} else {
+	default:
 		log.Fatalf("unknown prefix '%s'\n", s)
 	}
 	log.Debugf("config: %+v\n", c)

--- a/pkg/openers/sse.go
+++ b/pkg/openers/sse.go
@@ -43,7 +43,7 @@ func (f sseOpener) Open(s string, _ bool) (io.ReadCloser, error) {
 	// Convert sse:// to https://
 	url := strings.Replace(s, "sse://", "https://", 1)
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pcg/pcg32.go
+++ b/pkg/pcg/pcg32.go
@@ -13,7 +13,7 @@ func (pcg *PCG32) Next() uint32 {
 	return (xorshifted >> rot) | (xorshifted << ((-rot) & 31))
 }
 
-func NewPCG32(initState uint64, initSeq uint64) *PCG32 {
+func NewPCG32(initState, initSeq uint64) *PCG32 {
 	pcg := &PCG32{0, (initSeq << 1) | 1}
 	pcg.Next()
 	pcg.state += initState

--- a/pkg/scanners/scanners_test.go
+++ b/pkg/scanners/scanners_test.go
@@ -148,7 +148,7 @@ func TestScanWords(t *testing.T) {
 	testScanWords(t, text, words)
 }
 
-func testScanBytes(t *testing.T, text []byte, tokens []byte) {
+func testScanBytes(t *testing.T, text, tokens []byte) {
 	t.Helper()
 	buf := bytes.NewReader(text)
 	s := bufio.NewScanner(&slowReader{7, buf})

--- a/pkg/secretprovider/keyring_mock.go
+++ b/pkg/secretprovider/keyring_mock.go
@@ -12,7 +12,7 @@ import (
 var (
 	IsKeystoreAvailable = false
 	ErrNotCompiled      = errors.New("keystore not compiled in")
-	ErrNotFound         = errors.New("Not Found")
+	ErrNotFound         = errors.New("not found")
 )
 
 func SetSecret(name, _ string) error {


### PR DESCRIPTION
Closes #1164. **Linting was silently doing nothing** — the v1 config could not parse Go 1.27 export data, so every run failed at package load and reported only bogus `typecheck` noise. This migrates to v2 and fixes the backlog it exposed. Lint is now green: `0 issues`.

## Config

Migrated with the official `golangci-lint migrate`, plus three fixes found on the way:

- **`linter-settings` was a typo** for `linters-settings` — so `gofumpt: extra-rules: true` had *never* been applied. (The migration tool refused to run until this was corrected, which is how it surfaced.)
- `gomodguard` → `gomodguard_v2`, `gofumpt.extra-rules` → `gofumpt.extra.group-params` (both deprecated in v2)
- **`goconst` excluded from `_test.go`**: all 50 of its hits were repeated JSON fixtures in table-driven tests, where extracting constants would make the cases harder to read. No production code was flagged.

## Two real bugs

- **`stdCompress.go`** — `if bzr == nil` after `bzip2.NewReader` is dead code; that function never returns nil (staticcheck SA4023). Removed.
- **`pgzip.go`** — `log.Fatal` inside `cpgzip` ran *after* `defer zw.Close()`, so a `SetConcurrency` failure exited the process without flushing the gzip writer, truncating output. Now returns the error (gocritic `exitAfterDefer`).

## Dead code and cleanups

- Removed the unused `argSeparator` struct field and the unused `stdConfigStringJoinsArgs` helper
- `mc.go`: if-else chain → `switch`, trailing newline
- `sse.go`: `"GET"` → `http.MethodGet`
- `keyring_mock.go`: uncapitalized error string (ST1005)
- `log_test.go`: dropped redundant embedded-field selector (QF1008)
- Dropped two `//nolint:gosec` directives that no longer suppressed anything (they were superseded by the `#nosec` directives added in #1152)
- gofumpt formatting across four files

## One deliberate non-change

`openai.go` keeps the deprecated `MaxTokens` with a documented `//nolint`. ccat honours `OPENAI_BASE_URL`, so users point it at OpenAI-compatible servers (llama.cpp, ollama, LocalAI) that only understand `max_tokens`; switching to `MaxCompletionTokens` would silently break their token limits. That is a product decision, not a lint cleanup.

## Verified

`golangci-lint v2.13.1 run ./...` → **0 issues, no warnings**; `go test ./...` passes; builds green for default, `libcurl,crappy` and `nohl,fileonly` tags; `gosec -severity high` clean.

**`go fix` modernization follows in a separate PR** — it rewrites 32 files mechanically and would have buried the fixes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)