### PR TITLE
chore: go fix (Go 1.27 modernizers)

### DIFF
--- a/pkg/color/color_test.go
+++ b/pkg/color/color_test.go
@@ -22,7 +22,7 @@ func testNext(t *testing.T, c color.Color) {
 	t.Helper()
 	t.Run("donotpanicplease", func(t *testing.T) {
 		source := "hi"
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			c = c.Next()
 			s := c.Sprint(source)
 			if len(s) <= len(source) {

--- a/pkg/completion/hl.go
+++ b/pkg/completion/hl.go
@@ -1,5 +1,4 @@
 //go:build !nohl
-// +build !nohl
 
 package completion
 

--- a/pkg/highlighter/0interface.go
+++ b/pkg/highlighter/0interface.go
@@ -1,5 +1,4 @@
 //go:build !nohl
-// +build !nohl
 
 package highlighter
 

--- a/pkg/highlighter/chroma.go
+++ b/pkg/highlighter/chroma.go
@@ -1,5 +1,4 @@
 //go:build !nohl
-// +build !nohl
 
 package highlighter
 

--- a/pkg/lockable/flock.go
+++ b/pkg/lockable/flock.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package lockable
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -15,7 +15,7 @@ var (
 	Stderr = &Logger{Logger: log.New(os.Stderr, "", flags)}
 
 	DebugIsDiscard  int32
-	continueOnFatal int32
+	continueOnFatal atomic.Int32
 )
 
 func init() {
@@ -66,14 +66,14 @@ func Println(v ...any) {
 
 func Fatal(v ...any) {
 	Stderr.Output(2, fmt.Sprint(v...))
-	if atomic.LoadInt32(&continueOnFatal) <= 0 {
+	if continueOnFatal.Load() <= 0 {
 		os.Exit(1)
 	}
 }
 
 func Fatalf(format string, v ...any) {
 	Stderr.Output(2, fmt.Sprintf(format, v...))
-	if atomic.LoadInt32(&continueOnFatal) <= 0 {
+	if continueOnFatal.Load() <= 0 {
 		os.Exit(1)
 	}
 }
@@ -91,5 +91,5 @@ func Pp(data any) string {
 }
 
 func SetContinueOnFatal() {
-	atomic.StoreInt32(&continueOnFatal, 1)
+	continueOnFatal.Store(1)
 }

--- a/pkg/miniclaude/messagesapi.go
+++ b/pkg/miniclaude/messagesapi.go
@@ -107,7 +107,7 @@ stream:
 		if eventName == "error" {
 			log.Printf("error: %s", eventData)
 		}
-		var d map[string]interface{}
+		var d map[string]any
 		err = json.Unmarshal([]byte(eventData), &d)
 		if err != nil {
 			log.Debugf("error unmarshalling: %s\n%s\n", err, eventData)

--- a/pkg/miniclaude/types.go
+++ b/pkg/miniclaude/types.go
@@ -15,7 +15,7 @@ type Request struct {
 type MessagesResponse struct {
 	ID           string         `json:"id"`
 	Type         string         `json:"type"` // always "message"
-	Error        ErrorBlock     `json:"error,omitempty"`
+	Error        ErrorBlock     `json:"error"`
 	Role         string         `json:"role"` // always "assistant"
 	Content      []ContentBlock `json:"content"`
 	Model        string         `json:"model"`

--- a/pkg/mutators/pipeline/pipeline.go
+++ b/pkg/mutators/pipeline/pipeline.go
@@ -26,8 +26,8 @@ func NewPipeline(description string, out io.WriteCloser, in io.ReadCloser) error
 		globalPipeline.mu.Unlock()
 		return errors.New("empty pipeline requested")
 	}
-	list := strings.Split(description, mutators.StageSeparator)
-	for _, m := range list {
+	list := strings.SplitSeq(description, mutators.StageSeparator)
+	for m := range list {
 		log.Debugf("creating %v\n", m)
 		mutator, err := mutators.New(m)
 		if err != nil {

--- a/pkg/mutators/single/googleai.go
+++ b/pkg/mutators/single/googleai.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/batmac/ccat/pkg/log"
 	"github.com/google/generative-ai-go/genai"
@@ -55,15 +56,15 @@ func googleai(w io.WriteCloser, r io.ReadCloser, config any) (int64, error) {
 			return 0, err
 		}
 
-		p := ""
+		var p strings.Builder
 		for i, c := range resp.Candidates[0].Content.Parts {
 			log.Debugln("part ", i, ": ", c)
 			if t, ok := c.(genai.Text); ok {
-				p += string(t)
+				p.WriteString(string(t))
 			}
 		}
 
-		n, err := io.WriteString(w, p)
+		n, err := io.WriteString(w, p.String())
 		if err != nil {
 			return 0, err
 		}

--- a/pkg/mutators/single/jsonIndent.go
+++ b/pkg/mutators/single/jsonIndent.go
@@ -14,10 +14,7 @@ func init() {
 }
 
 func jsonIndent(w io.WriteCloser, r io.ReadCloser, config any) (int64, error) {
-	indent := cfgInt(config)
-	if indent < 0 {
-		indent = 0
-	}
+	indent := max(cfgInt(config), 0)
 	j, err := io.ReadAll(r) // NOT streamable
 	if err != nil {
 		return 0, err

--- a/pkg/mutators/single/jsonpath.go
+++ b/pkg/mutators/single/jsonpath.go
@@ -26,7 +26,7 @@ func jSONPath(w io.WriteCloser, r io.ReadCloser, config any) (int64, error) {
 		return 0, err
 	}
 
-	var v interface{}
+	var v any
 	if err := json.Unmarshal(buf, &v); err != nil {
 		return 0, err
 	}

--- a/pkg/mutators/single/ndjson.go
+++ b/pkg/mutators/single/ndjson.go
@@ -47,7 +47,7 @@ func NDJSONIndent(w io.WriteCloser, r io.ReadCloser, arg any) (int64, error) {
 		}
 
 		// Parse and pretty-print the JSON line
-		var jsonObj interface{}
+		var jsonObj any
 		if err := json.Unmarshal([]byte(line), &jsonObj); err != nil {
 			// If it's not valid JSON, write the line as-is
 			if _, err := fmt.Fprintln(w, line); err != nil {

--- a/pkg/openers/crng.go
+++ b/pkg/openers/crng.go
@@ -1,5 +1,4 @@
 //go:build !fileonly
-// +build !fileonly
 
 package openers
 

--- a/pkg/openers/crng_internal_test.go
+++ b/pkg/openers/crng_internal_test.go
@@ -1,5 +1,4 @@
 //go:build !fileonly
-// +build !fileonly
 
 package openers
 

--- a/pkg/openers/crng_test.go
+++ b/pkg/openers/crng_test.go
@@ -1,5 +1,4 @@
 //go:build !fileonly
-// +build !fileonly
 
 package openers_test
 

--- a/pkg/openers/echo.go
+++ b/pkg/openers/echo.go
@@ -1,5 +1,4 @@
 //go:build !fileonly
-// +build !fileonly
 
 package openers
 

--- a/pkg/openers/echo_test.go
+++ b/pkg/openers/echo_test.go
@@ -1,5 +1,4 @@
 //go:build !fileonly
-// +build !fileonly
 
 package openers_test
 

--- a/pkg/openers/gemini.go
+++ b/pkg/openers/gemini.go
@@ -1,5 +1,4 @@
 //go:build !fileonly
-// +build !fileonly
 
 package openers
 

--- a/pkg/openers/http.go
+++ b/pkg/openers/http.go
@@ -1,5 +1,4 @@
 //go:build !fileonly
-// +build !fileonly
 
 package openers
 

--- a/pkg/openers/http_test.go
+++ b/pkg/openers/http_test.go
@@ -1,5 +1,4 @@
 //go:build !fileonly
-// +build !fileonly
 
 package openers_test
 
@@ -29,7 +28,7 @@ func init() {
 
 	go func() {
 		// find an available port
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			m.Lock()
 			portTest = 10000 + rand.Intn(55000) //#nosec G404
 			m.Unlock()
@@ -38,7 +37,7 @@ func init() {
 	}()
 	go func() {
 		// find an available port
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			m.Lock()
 			insecurePortTest = 10000 + rand.Intn(55000) //#nosec G404
 			m.Unlock()

--- a/pkg/openers/mc.go
+++ b/pkg/openers/mc.go
@@ -1,5 +1,4 @@
 //go:build !fileonly
-// +build !fileonly
 
 package openers
 

--- a/pkg/openers/nc.go
+++ b/pkg/openers/nc.go
@@ -1,5 +1,4 @@
 //go:build !fileonly
-// +build !fileonly
 
 package openers
 

--- a/pkg/openers/prng.go
+++ b/pkg/openers/prng.go
@@ -1,5 +1,4 @@
 //go:build !fileonly
-// +build !fileonly
 
 package openers
 

--- a/pkg/openers/prng_internal_test.go
+++ b/pkg/openers/prng_internal_test.go
@@ -1,5 +1,4 @@
 //go:build !fileonly
-// +build !fileonly
 
 package openers
 

--- a/pkg/openers/prng_test.go
+++ b/pkg/openers/prng_test.go
@@ -1,5 +1,4 @@
 //go:build !fileonly
-// +build !fileonly
 
 package openers_test
 

--- a/pkg/openers/sse.go
+++ b/pkg/openers/sse.go
@@ -1,5 +1,4 @@
 //go:build !fileonly
-// +build !fileonly
 
 package openers
 
@@ -110,8 +109,8 @@ func (s *sseReadCloser) Read(p []byte) (int, error) {
 		}
 
 		// Only output data lines
-		if strings.HasPrefix(line, "data:") {
-			eventData := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if after, ok := strings.CutPrefix(line, "data:"); ok {
+			eventData := strings.TrimSpace(after)
 			s.buf.WriteString(eventData)
 			s.buf.WriteString("\n")
 			return s.buf.Read(p)

--- a/pkg/openers/wormhole.go
+++ b/pkg/openers/wormhole.go
@@ -1,5 +1,4 @@
 //go:build !fileonly
-// +build !fileonly
 
 package openers
 
@@ -39,10 +38,10 @@ func (f wormholeOpener) Description() string {
 }
 
 func (f wormholeOpener) Open(code string, _ bool) (io.ReadCloser, error) {
-	if strings.HasPrefix(code, "wormhole://") {
-		code = strings.TrimPrefix(code, "wormhole://")
-	} else if strings.HasPrefix(code, "wh://") {
-		code = strings.TrimPrefix(code, "wh://")
+	if after, ok := strings.CutPrefix(code, "wormhole://"); ok {
+		code = after
+	} else if after, ok := strings.CutPrefix(code, "wh://"); ok {
+		code = after
 	}
 
 	var c wormhole.Client

--- a/pkg/pcg/pcg32_test.go
+++ b/pkg/pcg/pcg32_test.go
@@ -44,7 +44,7 @@ func TestPCG32Output(t *testing.T) {
 	generated := make(map[uint32]struct{})
 	var firstValue uint32
 	allSame := true
-	for i := 0; i < count; i++ {
+	for i := range count {
 		v := rng.Next()
 		generated[v] = struct{}{}
 		if i == 0 {

--- a/pkg/secretprovider/keyring_mock.go
+++ b/pkg/secretprovider/keyring_mock.go
@@ -1,5 +1,4 @@
 //go:build !keystore
-// +build !keystore
 
 package secretprovider
 

--- a/pkg/stringutils/stringInSlice.go
+++ b/pkg/stringutils/stringInSlice.go
@@ -1,10 +1,7 @@
 package stringutils
 
+import "slices"
+
 func IsStringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, a)
 }

--- a/pkg/utils/test_helpers.go
+++ b/pkg/utils/test_helpers.go
@@ -5,7 +5,7 @@ import "testing"
 func CheckBytesRandomness(t *testing.T, data []byte) {
 	t.Helper()
 	acc := uint8(0)
-	for i := 0; i < len(data); i++ {
+	for i := range data {
 		acc |= data[i]
 	}
 	if acc != 0xFF {


### PR DESCRIPTION
Second half of the #1164 cleanup, kept separate so the real fixes in #1166 stayed reviewable. Produced entirely by `go fix ./...` — **zero hand-written changes, no behaviour changes**.

Despite touching 32 files, the diff is small (+29/-54) and splits cleanly:

**17 files — one deleted line each**: the obsolete `// +build` comment kept next to `//go:build`, only needed for Go < 1.17.

**15 files — small modernizations**:

| change | where |
|---|---|
| `continueOnFatal int32` + `atomic.Load/Store` → `atomic.Int32` | `pkg/log` |
| hand-rolled search loop → `slices.Contains` | `pkg/stringutils` |
| `if indent < 0 { indent = 0 }` → `max(cfgInt(config), 0)` | `jsonIndent` |
| `strings.HasPrefix` + manual slicing → `strings.CutPrefix` | `sse`, `wormhole`, `googleai` |
| `for i := 0; i < n; i++` → `for range n` | assorted |

## Verified

- Builds green on **all four tag sets**: default, `libcurl,crappy,keystore`, `nohl,fileonly`, `plugins,gcp,aws` — this matters here, since the `// +build` removals touch constraint lines
- `go test ./...` passes
- `golangci-lint` v2 still reports **0 issues**

Reproducible with `go fix ./...` on a Go 1.27 toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)