### PR TITLE
chore: go 1.27 everywhere

### DIFF
--- a/cmd/ccat/_gen/go.mod
+++ b/cmd/ccat/_gen/go.mod
@@ -1,8 +1,6 @@
 module github.com/batmac/ccat/cmd/ccat/_gen
 
-go 1.25.0
-
-toolchain go1.27.0
+go 1.27.0
 
 require mvdan.cc/gofumpt v0.11.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/batmac/ccat
 
-go 1.26
+go 1.27.0
 
 require (
 	cloud.google.com/go/storage v1.65.0


### PR DESCRIPTION
**CI was testing on Go 1.26.6 while the published Docker images were built with Go 1.27.** `actions/setup-go` resolves `go-version-file: go.mod`, and go.mod declared `go 1.26` — so the binaries users pull were never compiled by the toolchain that tested them.

Verified in the last main run:
```
Setup go version spec 1.26
Successfully set up Go version 1.26
go version go1.26.6 windows/amd64
```
…against `FROM golang:1.27-alpine` in both Dockerfiles.

## Changes

| file | before | after |
|---|---|---|
| `go.mod` | `go 1.26` | `go 1.27.0` |
| `cmd/ccat/_gen/go.mod` | `go 1.25.0` + `toolchain go1.27.0` | `go 1.27.0` |

The `_gen` module's `toolchain` line becomes redundant once the language version matches, and `go mod tidy` drops it. Nothing else needed touching: both Dockerfiles are already on `golang:1.27-alpine`, the devcontainer tracks the floating `1-bookworm` tag, and all four workflows read the version from go.mod — so they pick up 1.27 automatically from this one line.

## Implication

This makes **Go 1.27 the minimum to build from source**. In practice that is invisible: with the default `GOTOOLCHAIN=auto`, a user on an older toolchain downloads 1.27 automatically. Worth knowing if you ever need to support an older toolchain deliberately.

## Verified

Builds green on all four tag sets (default, `libcurl,crappy,keystore`, `nohl,fileonly`, `plugins,gcp,aws`), `go vet` clean, `go test ./...` passes, `golangci-lint` v2 reports 0 issues, and the `_gen` module builds. After merge, CI should report `go1.27.x` instead of `go1.26.6` — I will confirm on the main run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)