### PR TITLE
fix(build): run golangci-lint via go run, unbreak make janitor

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -90,10 +90,11 @@
   ],
   "customManagers": [
     {
-      "description": "go run tool pins in the Makefile",
+      "description": "go run tool pins in the Makefile and pre-commit config",
       "customType": "regex",
       "managerFilePatterns": [
-        "/^Makefile$/"
+        "/^Makefile$/",
+        "/^\\.pre-commit-config\\.yaml$/"
       ],
       "matchStrings": [
         "(?<depName>[a-z0-9./-]+(?:\\.[a-z]{2,})[^\\s@]*)@(?<currentValue>v[0-9][^\\s]*)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,15 +60,19 @@ repos:
       # - id: go-static-check # install https://staticcheck.io/docs/
       # - id: golangci-lint # requires github.com/golangci/golangci-lint
       # args: ["--allow-parallel-runners", "--go=1.17", "--config=.golangci.yml"]
-  - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.5.1
+  # golangci-lint runs via 'go run' rather than a hook calling the binary in
+  # $PATH: a golangci-lint built with an older Go than go.mod targets refuses
+  # to load the config, and the local toolchain always matches
+  - repo: local
     hooks:
-      # - id: go-generate
-        # args: ["."]
-      # - id: go-mod-tidy
-      - id: golangci-lint # requires github.com/golangci/golangci-lint
-        args:
-          ["--allow-parallel-runners", "--config=.golangci.yml"]
+      - id: golangci-lint
+        name: golangci-lint
+        language: system
+        types: [go]
+        pass_filenames: false
+        entry:
+          go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1
+          run --allow-parallel-runners --config=.golangci.yml
   - repo: https://github.com/renovatebot/pre-commit-hooks
     rev: 40.62.1
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 GOVULNCHECK := golang.org/x/vuln/cmd/govulncheck@v1.7.0
 GOSEC := github.com/securego/gosec/v2/cmd/gosec@v2.28.0
 GOFUMPT := mvdan.cc/gofumpt@v0.11.0
+GOLANGCI_LINT := github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1
+
+# advisories with no fixed version available, so govulncheck can never go green:
+# GO-2026-5932 is x/crypto/openpgp, reached through go-selfupdate. See
+# https://github.com/batmac/ccat/issues/1163
+VULN_IGNORE := GO-2026-5932
 
 build:
 	go run magefiles/mage.go
@@ -13,14 +19,20 @@ test:
 thanks:
 	gothanks
 
-# golangci-lint is expected in $PATH: it is still pinned to the v1 config
-# schema, see https://github.com/batmac/ccat/issues/1164
+# every tool runs via 'go run': the local toolchain builds it, so it always
+# targets the same Go version as go.mod (a golangci-lint binary built with an
+# older Go refuses to load a newer one)
 janitor:
-	golangci-lint run --disable-all -E misspell --fix ./...
-	golangci-lint run ./...
+	go run $(GOLANGCI_LINT) run --enable-only misspell --fix ./...
+	go run $(GOLANGCI_LINT) run ./...
 	go run $(GOFUMPT) -w -l .
-	go run $(GOSEC) -severity high ./...
-	go run $(GOVULNCHECK) ./...
+	go run $(GOSEC) -severity high -exclude-dir=old ./...
+	@out="$$(go run $(GOVULNCHECK) ./... 2>&1 || true)"; \
+	echo "$$out"; \
+	if echo "$$out" | grep -E '^Vulnerability #' | grep -qv '$(VULN_IGNORE)'; then \
+		echo "==> govulncheck found a vulnerability other than $(VULN_IGNORE)"; \
+		exit 1; \
+	fi
 
 release:
 	goreleaser release --clean


### PR DESCRIPTION
`make janitor` was broken:

```
can't load config: the Go language version (go1.26) used to build golangci-lint
is lower than the targeted Go version (1.27.0)
```

My miss in #1166: that PR migrated the *config* to v2 but left the Makefile and the pre-commit hook invoking whatever `golangci-lint` happens to be in `$PATH` — still v1.64.8 built with Go 1.26 here. Building the linter with `go run` means the local toolchain compiles it, so it always targets the same Go version as go.mod.

Four fixes, each found by actually running the target until it exited 0:

1. **golangci-lint via `go run`** (pinned `@v2.13.1`, like GOSEC/GOFUMPT/GOVULNCHECK), in both the Makefile and `.pre-commit-config.yaml`. The pre-commit hook had the identical problem — it is skipped on pre-commit.ci, so it only ever failed locally.
2. **`--disable-all -E misspell` → `--enable-only misspell`** — v2 removed the old flag pair.
3. **gosec: `-exclude-dir=old`** — the gitignored `old/` scratch directory contains a second module and broke gosec's package loading (`found packages openers and main in old/magnet`).
4. **govulncheck: ignore GO-2026-5932 by id.** It is the `x/crypto/openpgp` advisory reaching us through go-selfupdate, and it has **no fixed version** (#1163) — so the target could *never* pass, and a check that always fails is a check nobody runs. Any other advisory still fails the build.

On that last point, I verified the guard rather than trusting it: temporarily changing the ignored id makes `make janitor` exit non-zero on the very same advisory, and restoring it exits 0. (Amusing detail: my first interactive test of the grep logic gave inverted results because this shell wraps `grep` in a function — `make` uses `/bin/sh`, and against the real `/usr/bin/grep` the three cases behave as designed.)

Renovate's custom manager now watches `.pre-commit-config.yaml` as well as the Makefile, so both pinned versions keep updating.

**Verified**: `make janitor` exits **0**, running golangci-lint (0 issues), gofumpt, gosec (0 issues) and govulncheck end to end; `pre-commit run golangci-lint --all-files` passes; renovate config validates against v43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)