### PR TITLE
chore(renovate): automerge pinDigest updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,7 @@
         "minor",
         "patch",
         "pin",
+        "pinDigest",
         "digest"
       ]
     },


### PR DESCRIPTION
`pinDigest` is a distinct Renovate update type from `pin` and `digest`: it covers the *first* pinning of a ref that is currently a bare tag. It was missing from the automerge rule, so digest **refreshes** merged themselves weekly while the initial **pinning** always parked waiting for a manual merge — visible on #1171, whose body reads "Automerge: Disabled by config".

Every actions-major round rewrites refs back to bare tags (a major bump drops the digest), so Renovate raises a `pinDigest` PR after each one. Those don't need a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)