### PR TITLE
chore(renovate): stop proposing major bumps of indirect deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -66,6 +66,19 @@
       "groupName": "go indirect dependencies"
     },
     {
+      "description": "a Go major bump is an import-path change, so for an indirect dep it can only happen inside the parent module; nothing here can act on it",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepTypes": [
+        "indirect"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    },
+    {
       "description": "constrained by the deprecated github.com/google/generative-ai-go, whose build breaks against newer go/ai; remove after migrating to google.golang.org/genai",
       "matchManagers": [
         "gomod"


### PR DESCRIPTION
In Go a major version is part of the import path, so bumping one means editing `import` statements inside the module that requires it. For an **indirect** dependency that module is not this repo — and nothing in `ccat` imports these packages — so the update can never be actioned here. `gomodTidy` would revert it anyway.

The dependency dashboard (#10) has been offering four of them every week:

| suggestion | why it is impossible |
|---|---|
| `go.yaml.in/yaml/v2` → `v3.0.5` | `go.yaml.in/yaml/v3 v3.0.5` is **already in go.mod** — both are pulled in by different parents |
| `gopkg.in/yaml.v2` → `v3.0.1` | same: `gopkg.in/yaml.v3 v3.0.1` is already there |
| `github.com/google/go-github/v86` → `v90` | indirect, owned by go-selfupdate |
| `gitlab.com/gitlab-org/api/client-go` → `v2` | indirect |

Minor and patch updates for indirect deps still flow through the existing `go indirect dependencies` group, so transitive security fixes are unaffected. Validated with `renovate-config-validator` v44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)