### PR TITLE
chore(renovate): document every rule, drop the inert digest gate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": [
+    "Update policy for this repo, in one place. Renovate opens one grouped batch of PRs on Monday mornings (Europe/Paris).",
+    "Minor, patch and digest updates merge themselves once the required checks are green. Majors do not: they wait for you to tick their box on the Dependency Dashboard (issue #10), and merge once you do.",
+    "Nothing is proposed until it has been public for 7 days (minimumReleaseAge), which is the main defence against a compromised or yanked release.",
+    "GitHub Actions and Docker base images are pinned to digests, so a moving tag cannot change what CI runs without a PR.",
+    "Every packageRule below carries a description saying why it exists; keep it that way, and delete a rule rather than leaving it unexplained."
+  ],
   "dependencyDashboardAutoclose": true,
   "extends": [
     "config:recommended",
@@ -20,6 +27,7 @@
   },
   "packageRules": [
     {
+      "description": "the routine case: low-risk updates merge themselves once the required checks pass. The 7-day minimumReleaseAge and the test matrix are the gate here, not human review.",
       "automerge": true,
       "matchUpdateTypes": [
         "minor",
@@ -30,6 +38,7 @@
       ]
     },
     {
+      "description": "majors can break the build or change behaviour, so they wait for a human to tick their box on the Dependency Dashboard (issue #10). automerge still applies afterwards: approving on the dashboard IS the approval, and the PR merges once checks are green.",
       "automerge": true,
       "dependencyDashboardApproval": true,
       "matchUpdateTypes": [
@@ -37,6 +46,7 @@
       ]
     },
     {
+      "description": "the exception to the rule above. Action majors are almost always a runner or Node runtime bump rather than a behaviour change, they are covered by every workflow running on the PR itself, and the digests are pinned, so waiting on a human buys nothing.",
       "groupName": "github actions (major)",
       "matchManagers": [
         "github-actions"
@@ -48,14 +58,7 @@
       "dependencyDashboardApproval": false
     },
     {
-      "matchManagers": [
-        "gomod"
-      ],
-      "digest": {
-        "dependencyDashboardApproval": true
-      }
-    },
-    {
+      "description": "Renovate ignores indirect Go dependencies unless told otherwise, so 'enabled' here is load-bearing, not a no-op. Grouping them keeps transitive churn to a single PR.",
       "matchManagers": [
         "gomod"
       ],
@@ -89,6 +92,7 @@
       "enabled": false
     },
     {
+      "description": "the AWS SDK ships a release most weekdays and splits into ~15 modules, so the default schedule would bury every other update. Monthly, grouped, is enough for an S3 opener.",
       "groupName": "aws-go-sdk-v2 monorepo",
       "groupSlug": "aws-go-sdk-v2",
       "matchDatasources": [


### PR DESCRIPTION
The config had grown to seven `packageRules` with a single `description` between them. That's the real maintenance cost of a config like this — not its length, but that nobody can tell which rules are load-bearing and which are fossils, so nothing ever gets deleted.

**Added** a top-level `description` stating the policy in five lines (weekly batches, automerge on green, majors gated on the dashboard #10, 7-day release age, digest pinning), plus a `description` on every rule. Three of them genuinely read as mistakes without one:

- `"enabled": true` on the indirect rule looks like a no-op — Renovate skips indirect Go deps unless told otherwise, so it's required.
- The majors rule carries **both** `automerge` and `dependencyDashboardApproval`, which looks contradictory until you know that ticking the dashboard box *is* the approval.
- The github-actions majors rule deliberately bypasses that gate.

**Removed** the gomod digest rule:

```json
{ "matchManagers": ["gomod"], "digest": { "dependencyDashboardApproval": true } }
```

It used a nested update-type object that never took effect — the `golang.org/x/exp` digest branch was created without the update ever appearing under *Pending Approval* on #10 — and it contradicted the automerge rule above it. Pseudo-version bumps now ride the same test matrix and 7-day age gate as every other dep.

**No other behaviour change.** The diff is description strings plus that one deletion. Validated with `renovate-config-validator` v44.39 (the hosted app's version) and v40.62.1 (the version pinned in `.pre-commit-config.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)